### PR TITLE
Changing "port" to "expose" and mappings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,39 +8,39 @@ services:
   filters:
     build: ./MateCatFilters/
     container_name: docker_matecat_filter
-    ports:
-      - 8732:8732
+    expose:
+      - 8732
     networks:
        - matecat-network
 
   redis:
     image: redis
-    ports:
-      - 6379:6379
+    expose:
+      - 6379
     networks:
        - matecat-network
 
   amq:
     image: webcenter/activemq:latest
-    ports:
-      - 61613:61613
-      - 61616:61616
-      - 8161:8161
+    expose:
+      - 61613
+      - 61616
+      - 8161
     networks:
        - matecat-network
        
   mysql:
     build: ./MySQL/
     container_name: docker_mysql
-    ports:
-     - 3306:3306
+    expose:
+     - 3306
     networks:
        - matecat-network
 
   mosesdecoder:
     build: ./Moses/
-    ports:
-     - 8000:8080
+    expose:
+     - 8000
     networks:
      - matecat-network
 
@@ -50,9 +50,7 @@ services:
     volumes:
       - ~/matecat:/var/www/matecat:rw
     ports:
-      - 80:80
-      - 7788:7788
-      - 22
+      - 80
     networks:
        - matecat-network
     links:


### PR DESCRIPTION
Hi,
Thanks for this repo, it is very useful.
I would suggest to use "expose" instead of "ports" so that these ports are only available inside the network created by docker-compose and don't get bound to the host. This way it won't interfere with anything that is already running on the host and also it's better for security.

A couple of questions:
- The Moses decoder had the port mapping 8000:8080. Is this intentional? If have changed it to expose 8000
- Do we need access to port 22 on the matecat container? I have deleted it for now.
- What does port 7788 on the matecat container do? I have deleted it for now.